### PR TITLE
Improve error logs

### DIFF
--- a/src/jira-connector.ts
+++ b/src/jira-connector.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosInstance } from 'axios';
+import { isAxiosError } from './utils';
 import { getInputs } from './action-inputs';
 import { JIRA, JIRADetails } from './types';
+import { error as coreError, info as coreInfo } from '@actions/core';
 
 export class JiraConnector {
   client: AxiosInstance;
@@ -46,6 +48,10 @@ export class JiraConnector {
         },
       };
     } catch (error) {
+      if (isAxiosError(error) && error?.response?.status === 401) {
+        coreError('Jira request failed, check your jira-token.');
+        coreInfo('Does your jira-token include the required prefix ? See https://github.com/cakeinpanic/jira-description-action#jira-token');
+      }
       throw error;
     }
   }

--- a/src/jira-connector.ts
+++ b/src/jira-connector.ts
@@ -46,9 +46,6 @@ export class JiraConnector {
         },
       };
     } catch (error) {
-      if (error.response) {
-        throw new Error(JSON.stringify(error.response, null, 4));
-      }
       throw error;
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,6 @@ async function run(): Promise<void> {
     const details = await jiraConnector.getTicketDetails(issueKey);
     await githubConnector.updatePrDetails(details);
   } catch (error) {
-    console.log('JIRA key was not found');
     core.error(error.message);
 
     if (FAIL_WHEN_JIRA_ISSUE_NOT_FOUND) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import {
   WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS,
 } from './constants';
 import { JIRADetails } from './types';
+import { AxiosError } from 'axios';
 
 const getJIRAIssueKey = (input: string, regexp: RegExp = JIRA_REGEX_MATCHER): string | null => {
   const matches = regexp.exec(input);
@@ -78,3 +79,5 @@ export const buildPRDescription = (details: JIRADetails) => {
  
 `;
 };
+
+export const isAxiosError = <T = any>(err: Error): err is AxiosError<T> => !!(err as AxiosError)?.isAxiosError;


### PR DESCRIPTION
- Removed obsolete error log ([300d187](https://github.com/cakeinpanic/jira-description-action/commit/300d1878626cf96858b96bb3a38f4174a8a1239f))

> I think it is a duplicate from the [github-connector.](https://github.com/cakeinpanic/jira-description-action/blob/573d376cf6754eb13126a2cca59905dc7332e65e/src/github-connector.ts#L49)

- Add log to suggest checking the jira-token when the jira GET request fails with status code 401 ([58d17dd](https://github.com/cakeinpanic/jira-description-action/commit/58d17dd35974bb1fb4f5689d5160f01197726ac0))

> Solves #33 