### PR TITLE
fix: warning message duplicate

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -64,8 +64,8 @@ describe('getPRDescription()', () => {
     const issueInfo = 'new info about jira task';
     const description = getPRDescription(oldPRBody, issueInfo);
 
-    expect(description).toEqual(`${WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS}
-${HIDDEN_MARKER_START}
+    expect(description).toEqual(`${HIDDEN_MARKER_START}
+${WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS}
 ${issueInfo}
 ${HIDDEN_MARKER_END}
 ${oldPRBody}`);
@@ -78,8 +78,8 @@ ${oldPRBody}`);
 
     const description = getPRDescription(oldPRBody, issueInfo);
 
-    expect(description).toEqual(`${WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS}
-${HIDDEN_MARKER_START}
+    expect(description).toEqual(`${HIDDEN_MARKER_START}
+${WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS}
 ${issueInfo}
 ${HIDDEN_MARKER_END}
 ${oldPRBodyInformation}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,8 +60,8 @@ export const getPRDescription = (oldBody: string, details: string): string => {
   const rg = new RegExp(`${hiddenMarkerStartRg}([\\s\\S]+)${hiddenMarkerEndRg}`, 'igm');
   const bodyWithoutJiraDetails = (oldBody ?? '').replace(rg, '');
 
-  return `${WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS}
-${HIDDEN_MARKER_START}
+  return `${HIDDEN_MARKER_START}
+${WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS}
 ${details}
 ${HIDDEN_MARKER_END}
 ${bodyWithoutJiraDetails}`;


### PR DESCRIPTION
## Steps to reproduce

- Create simple `pull_request` workflow file : 

```yml
# .github/workflows/pr-description.yml
name: Set PR description
on:
  pull_request:
    types: [opened, synchronize, edited, reopened, ready_for_review]

jobs:
  update-pr-body:
    name: 💬 Jira details
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v3

      - uses: cakeinpanic/jira-description-action@0.3.3
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          jira-token: ${{ secrets.JIRA_TOKEN }}
          jira-base-url: [your jira base URL]
          jira-project-key: [your jira project key]
          use: both
```

- Open a pull-request containing this file
- Wait until the workflow finishes, you should see the following description :
```
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
...
</table>
<br />

<!--jira-description-action-hidden-marker-end-->
```
- Go to to the latest workflow run in the **Actions** tab, and click "**Re-run all jobs**
- Wait until the workflow finishes, you should see the following description :
```
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
...
</table>
<br />

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
```

The `WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS` is being stacked on each update.