### PR TITLE
fix: stringify response data instead of whole response

### DIFF
--- a/src/jira-connector.ts
+++ b/src/jira-connector.ts
@@ -46,8 +46,9 @@ export class JiraConnector {
         },
       };
     } catch (error) {
+      console.log('Error fetching details from JIRA.')
       if (error.response) {
-        throw new Error(JSON.stringify(error.response, null, 4));
+        throw new Error(JSON.stringify(error.response.data, null, 4));
       }
       throw error;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function run(): Promise<void> {
     const details = await jiraConnector.getTicketDetails(issueKey);
     await githubConnector.updatePrDetails(details);
   } catch (error) {
-    console.log('JIRA key was not found');
+    console.log('Failed to add JIRA description to PR.');
     core.error(error.message);
 
     if (FAIL_WHEN_JIRA_ISSUE_NOT_FOUND) {


### PR DESCRIPTION
## Changes
- fixes a circular structure error by stringifying `error.response.data`
- adds a couple of console logs

## Background
I started receiving the following error in my GitHub action:

```log
JIRA key found -> ***-***
Fetching ***-*** details from JIRA
JIRA key was not found
Error: Converting circular structure to JSON
    --> starting at object with constructor 'ClientRequest'
    |     property 'socket' -> object with constructor 'TLSSocket'
    --- property '_httpMessage' closes the circle
```

I believe this is related to the way the error response is being used, which is preventing the real error from being logged.