### PR TITLE
Use valid table HTML for PR description

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import { HIDDEN_MARKER_END, HIDDEN_MARKER_START, WARNING_MESSAGE_ABOUT_HIDDEN_MARKERS } from '../src/constants';
-import { getJIRAIssueKeyByDefaultRegexp, getJIRAIssueKeysByCustomRegexp, getPRDescription, shouldSkipBranch } from '../src/utils';
+import { JIRADetails } from '../src/types';
+import { getJIRAIssueKeyByDefaultRegexp, getJIRAIssueKeysByCustomRegexp, getPRDescription, shouldSkipBranch, buildPRDescription } from '../src/utils';
 
 jest.spyOn(console, 'log').mockImplementation(); // avoid actual console.log in test output
 
@@ -110,5 +111,40 @@ ${HIDDEN_MARKER_END}
 this is text below the markers`;
     const description = getPRDescription(oldPRDescription, issueInfo);
     expect(description).toEqual(oldPRDescription);
+  });
+});
+
+describe('buildPRDescription()', () => {
+  it('should return description HTML from the JIRA details', () => {
+    const details: JIRADetails = {
+      key: 'ABC-123',
+      summary: 'Sample summary',
+      url: 'example.com/ABC-123',
+      type: {
+        name: 'story',
+        icon: 'icon.png',
+      },
+      project: {
+        name: 'name',
+        url: 'url',
+        key: 'key',
+      },
+    };
+
+    expect(buildPRDescription(details)).toEqual(`
+    <table>
+      <tbody>
+        <tr>
+          <td>
+            <a href="example.com/ABC-123" title="ABC-123" target="_blank">
+              <img alt="story" src="icon.png" />
+              ABC-123
+            </a>
+            Sample summary
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <br />`);
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -131,20 +131,9 @@ describe('buildPRDescription()', () => {
       },
     };
 
-    expect(buildPRDescription(details)).toEqual(`
-    <table>
-      <tbody>
-        <tr>
-          <td>
-            <a href="example.com/ABC-123" title="ABC-123" target="_blank">
-              <img alt="story" src="icon.png" />
-              ABC-123
-            </a>
-            Sample summary
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <br />`);
+    expect(buildPRDescription(details)).toEqual(`<table><tbody><tr><td>
+  <a href="example.com/ABC-123" title="ABC-123" target="_blank"><img alt="story" src="icon.png" /> ABC-123</a>
+  Sample summary
+</td></tr></tbody></table><br />`);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,11 +74,18 @@ ${HIDDEN_MARKER_END}
 export const buildPRDescription = (details: JIRADetails) => {
   const displayKey = details.key.toUpperCase();
   return `
-<table>
-<td>
-  <a href="${details.url}" title="${displayKey}" target="_blank"><img alt="${details.type.name}" src="${details.type.icon}" />${displayKey}</a>  ${details.summary}
-  </td></table>
-  <br />
- 
-`;
+    <table>
+      <tbody>
+        <tr>
+          <td>
+            <a href="${details.url}" title="${displayKey}" target="_blank">
+              <img alt="${details.type.name}" src="${details.type.icon}" />
+              ${displayKey}
+            </a>
+            ${details.summary}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <br />`;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,19 +73,8 @@ ${HIDDEN_MARKER_END}
 
 export const buildPRDescription = (details: JIRADetails) => {
   const displayKey = details.key.toUpperCase();
-  return `
-    <table>
-      <tbody>
-        <tr>
-          <td>
-            <a href="${details.url}" title="${displayKey}" target="_blank">
-              <img alt="${details.type.name}" src="${details.type.icon}" />
-              ${displayKey}
-            </a>
-            ${details.summary}
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <br />`;
+  return `<table><tbody><tr><td>
+  <a href="${details.url}" title="${displayKey}" target="_blank"><img alt="${details.type.name}" src="${details.type.icon}" /> ${displayKey}</a>
+  ${details.summary}
+</td></tr></tbody></table><br />`;
 };


### PR DESCRIPTION
This updates the PR description output to use valid table HTML and adds a test case as the `buildPRDescription` method didn't have any coverage. I'd like to do a future update to improve the layout of the table contents but wanted to get this in first.