### PR TITLE
Remove line break

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -134,6 +134,6 @@ describe('buildPRDescription()', () => {
     expect(buildPRDescription(details)).toEqual(`<table><tbody><tr><td>
   <a href="example.com/ABC-123" title="ABC-123" target="_blank"><img alt="story" src="icon.png" /> ABC-123</a>
   Sample summary
-</td></tr></tbody></table><br />`);
+</td></tr></tbody></table>`);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,5 +76,5 @@ export const buildPRDescription = (details: JIRADetails) => {
   return `<table><tbody><tr><td>
   <a href="${details.url}" title="${displayKey}" target="_blank"><img alt="${details.type.name}" src="${details.type.icon}" /> ${displayKey}</a>
   ${details.summary}
-</td></tr></tbody></table><br />`;
+</td></tr></tbody></table>`;
 };


### PR DESCRIPTION
Line break in the PR description can be handled directly in PR template on user side (or manually when adding description).

Thanks to that PR "UI" description is better :)

P.S : thank you for this great action!